### PR TITLE
change MkDocs destination directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *~
 .*
 
-html/
+docs-html/
 htmlcov/
 coverage/
 build/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
 site_name: geometalab.drf-utm-zone-info
 site_description: Django REST framework app providing information about Universal Transverse Mercator (UTM) zones
 repo_url: https://github.com/geometalab/drf-utm-zone-info
-site_dir: html
+site_dir: docs-html


### PR DESCRIPTION
This avoids conflicts with the `html` Python standard library package due to mkdocs/mkdocs#807 in older MkDocs versions. But mostly, it's more clear, anyway.